### PR TITLE
Dev 3

### DIFF
--- a/assets/schema/current.xsd
+++ b/assets/schema/current.xsd
@@ -440,6 +440,17 @@
                                     <xs:attribute name="key-event-id" />
                                 </xs:complexType>
                             </xs:element>
+                            <xs:element name="key-events" maxOccurs="unbounded" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element>
+                                            <xs:complexType>
+                                                <xs:attribute name="id" />
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
                             <xs:element name="adverse-outcome" minOccurs="0" maxOccurs="unbounded">
                                 <xs:complexType>
                                     <xs:sequence>

--- a/assets/schema/current.xsd
+++ b/assets/schema/current.xsd
@@ -143,7 +143,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="oecd-status">
+            <xs:element name="oecd-status" minOccurs="0">
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
                         <xs:enumeration value="WPHA/WNT Endorsed" />
@@ -229,7 +229,7 @@
                         <xs:complexContent>
                             <xs:extension base="biological-term-type">
                                 <xs:sequence>
-                                    <xs:element name="biological-organization" type="biological-organization-level-type" />
+                                    
                                 </xs:sequence>
                                 <xs:attribute name="id" type="guid" use="required" />
                             </xs:extension>
@@ -241,7 +241,7 @@
                         <xs:complexContent>
                             <xs:extension base="biological-term-type">
                                 <xs:sequence>
-                                    <xs:element name="biological-organization" type="biological-organization-level-type" />
+                                    
                                 </xs:sequence>
                                 <xs:attribute name="id" type="guid" use="required" />
                             </xs:extension>
@@ -328,7 +328,7 @@
                                             <xs:complexType>
                                                 <xs:complexContent>
                                                     <xs:extension base="evidence-type">
-                                                        <xs:attribute name="id" type="guid" use="required" />
+                                                        <xs:attribute name="stressor-id" type="guid" use="required" />
                                                     </xs:extension>
                                                 </xs:complexContent>
                                             </xs:complexType>
@@ -437,15 +437,15 @@
                                     <xs:sequence>
                                         <xs:element name="evidence-supporting-chemical-initiation" type="xs:string" minOccurs="0" />
                                     </xs:sequence>
-                                    <xs:attribute name="key-event-id" />
+                                    <xs:attribute name="key-event-id"  type="guid"  use="required" />
                                 </xs:complexType>
                             </xs:element>
-                            <xs:element name="key-events" maxOccurs="unbounded" minOccurs="0">
+                            <xs:element name="key-events" maxOccurs="1" minOccurs="0">
                                 <xs:complexType>
                                     <xs:sequence>
-                                        <xs:element>
+                                        <xs:element name="key-event" minOccurs="0" maxOccurs="unbounded">
                                             <xs:complexType>
-                                                <xs:attribute name="id" />
+                                                <xs:attribute name="key-event-id"  type="guid"  use="required" />
                                             </xs:complexType>
                                         </xs:element>
                                     </xs:sequence>
@@ -469,7 +469,7 @@
                                             </xs:complexType>
                                         </xs:element>
                                     </xs:sequence>
-                                    <xs:attribute name="key-event-id" type="guid" />
+                                    <xs:attribute name="key-event-id" type="guid"  use="required" />
                                 </xs:complexType>
                             </xs:element>
                             <xs:element name="key-event-relationships">
@@ -532,7 +532,7 @@
                                             <xs:complexType>
                                                 <xs:complexContent>
                                                     <xs:extension base="evidence-type">
-                                                        <xs:attribute name="stressor-id" type="guid" use="required" />
+														<xs:attribute name="stressor-id" type="guid" use="required" />
                                                     </xs:extension>
                                                 </xs:complexContent>
                                             </xs:complexType>

--- a/assets/schema/current.xsd
+++ b/assets/schema/current.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.aopkb.org/aop-xml" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified" vc:minVersion="1.1" targetNamespace="http://www.aopkb.org/aop-xml">
     <xs:simpleType name="guid">
         <xs:annotation>
@@ -139,13 +139,14 @@
                         <xs:enumeration value="Open for adoption" />
                         <xs:enumeration value="Not under active development" />
                         <xs:enumeration value="Under development: Not open for comment. Do not cite" />
+                        <xs:enumeration value="Under Development: Contributions and Comments Welcome" />
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
             <xs:element name="oecd-status">
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
-                        <xs:enumeration value="TFHA/WNT Endorsed" />
+                        <xs:enumeration value="WPHA/WNT Endorsed" />
                         <xs:enumeration value="EAGMST Approved" />
                         <xs:enumeration value="EAGMST Under Review" />
                         <xs:enumeration value="Under Development" />

--- a/assets/schema/current.xsd
+++ b/assets/schema/current.xsd
@@ -184,9 +184,9 @@
     </xs:simpleType>
     <xs:simpleType name="confidence-level-type">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="Strong" />
+            <xs:enumeration value="High" />
             <xs:enumeration value="Moderate" />
-            <xs:enumeration value="Weak" />
+            <xs:enumeration value="Low" />
             <xs:enumeration value="Not Specified" />
         </xs:restriction>
     </xs:simpleType>

--- a/assets/schema/current.xsd
+++ b/assets/schema/current.xsd
@@ -78,6 +78,7 @@
                                             <xs:enumeration value="Development" />
                                             <xs:enumeration value="All life stages" />
                                             <xs:enumeration value="Fetal" />
+                                            <xs:enumeration value="Larvae" />
                                         </xs:restriction>
                                     </xs:simpleType>
                                 </xs:element>
@@ -153,7 +154,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="saaop-status">
+            <xs:element name="saaop-status" minOccurs="0">
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
                         <xs:enumeration value="Included in OECD Work Plan" />

--- a/assets/schema/current.xsd
+++ b/assets/schema/current.xsd
@@ -429,6 +429,7 @@
                             <xs:element name="short-name" type="xs:string" />
                             <xs:element name="authors" type="xs:string" />
                             <xs:element name="status" type="status" />
+                            <xs:element name="oecd-project" type="xs:string" />
                             <xs:element name="abstract" type="xs:string" />
                             <xs:element name="background" type="xs:string" minOccurs="0" />
                             <xs:element name="molecular-initiating-event" maxOccurs="unbounded" minOccurs="0">
@@ -520,7 +521,7 @@
                                             <xs:complexType>
                                                 <xs:complexContent>
                                                     <xs:extension base="evidence-type">
-                                                        <xs:attribute name="id" type="guid" use="required" />
+                                                        <xs:attribute name="stressor-id" type="guid" use="required" />
                                                     </xs:extension>
                                                 </xs:complexContent>
                                             </xs:complexType>

--- a/assets/schema/current.xsd
+++ b/assets/schema/current.xsd
@@ -399,7 +399,7 @@
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>
-                            <xs:element name="taxonomic-applicability" type="applicability-type" minOccurs="0" />
+                            <xs:element name="applicability" type="applicability-type" minOccurs="0" />
                             <xs:element name="evidence-supporting-taxonomic-applicability" type="xs:string" minOccurs="0" />
                             <xs:element name="references" type="xs:string" minOccurs="0" />
                             <xs:element name="source" minOccurs="0">

--- a/assets/schema/current.xsd
+++ b/assets/schema/current.xsd
@@ -468,11 +468,11 @@
                                         <xs:element name="relationship" minOccurs="0" maxOccurs="unbounded">
                                             <xs:complexType>
                                                 <xs:sequence>
-                                                    <xs:element name="directness">
+                                                    <xs:element name="adjacency">
                                                         <xs:simpleType>
                                                             <xs:restriction base="xs:string">
-                                                                <xs:enumeration value="direct" />
-                                                                <xs:enumeration value="indirect" />
+                                                                <xs:enumeration value="adjacent" />
+                                                                <xs:enumeration value="non-adjacent" />
                                                             </xs:restriction>
                                                         </xs:simpleType>
                                                     </xs:element>

--- a/assets/schema/current.xsd
+++ b/assets/schema/current.xsd
@@ -472,7 +472,7 @@
                                     <xs:attribute name="key-event-id" type="guid"  use="required" />
                                 </xs:complexType>
                             </xs:element>
-                            <xs:element name="key-event-relationships">
+                            <xs:element name="key-event-relationships" maxOccurs="1" minOccurs="0">
                                 <xs:complexType>
                                     <xs:sequence>
                                         <xs:element name="relationship" maxOccurs="unbounded">


### PR DESCRIPTION
Merge #4 before this one. This includes those changes, so there shouldn't be any conflicts.

Addresses #3 and other validation errors when coupled with corresponding changes to the AOP-Wiki.
- Updates OECD and SAAOP status fields
- Explicitly includes all key events for an AOP
- Adds oecd-project field
- Removes level of biological organization from objects and processes. This is specified at the key event level.
- Fixes names of identifiers to match AOP-Wiki tags
- Renames applicability section for KERs to match KEs and AOPs
- Added new life stage term: Larvae
- Made OECD and SAAOP status designations optional (may reverse SAAOP change before deployment)